### PR TITLE
Bugfix error handling

### DIFF
--- a/src/typetalk.coffee
+++ b/src/typetalk.coffee
@@ -76,7 +76,7 @@ class TypetalkStreaming extends EventEmitter
         process.exit 1
 
     unless @rate > 0
-      @robot.logger.error 'API rate must be greater then 0'
+      @robot.logger.error 'API rate must be greater than 0'
       process.exit 1
 
   Profile: (callback) ->


### PR DESCRIPTION
Right now, when a wrong value is provided to HUBOT_TYPETALK_ROOMS, it shows error messages but doesn't really halt. And the messages don't really communicate what the problems is like other parts of the program do.

I added a few lines of code to improve it. I don't know if you like it, please have a look.
