### PR TITLE
fix the typo of the variable name

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "blanket": "^1.2.0",
     "chai": "*",
     "coffee-script": "~1.6.3",
-    "coveralls": "~2.11.6",
+    "coveralls": "~2.11.9",
     "mocha": "*",
     "mocha-lcov-reporter": "0.0.1",
     "nock": "~0.27.2"

--- a/src/typetalk.coffee
+++ b/src/typetalk.coffee
@@ -76,10 +76,10 @@ class TypetalkStreaming extends EventEmitter
                            headers:
                              'Authorization'         : "Bearer #{@accessToken}"
                              'User-Agent'            : "#{Package.name} v#{Package.version}"
-      conneted = false
+      connected = false
 
       ws.on 'open', () =>
-        conneted = true
+        connected = true
         setInterval =>
           ws.ping 'ping'
         , 1000 * 60 * 10


### PR DESCRIPTION
Maybe.. I think this is a typo.