### PR TITLE
add custom constructor to robot mock

### DIFF
--- a/test/mock/robot.coffee
+++ b/test/mock/robot.coffee
@@ -1,8 +1,11 @@
 {Robot} = require 'hubot'
 
 class RobotMock extends Robot
+
+  constructor: (Adapter) ->
+    super null, Adapter
+
   loadAdapter: (Adapter) ->
     @adapter = Adapter.use this
 
 module.exports = RobotMock
-


### PR DESCRIPTION

The current test failed.
The cause is the part to pass the Adapter to the constructor of robot.coffee.
I extended the robot Mock.

Please check it :-)

```
[vvatanabe@yuichiwatanabe]# make test 
./node_modules/.bin/mocha test

  Typetalk
    #run
      1) "before each" hook for "should emmit on connected"

  TypetalkStreaming
    2) "before each" hook for "should have configs from environment variables"


  0 passing (14ms)
  2 failing

  1) Typetalk "before each" hook for "should emmit on connected":
     TypeError: Cannot read property 'use' of undefined
      at RobotMock.loadAdapter (test/mock/robot.coffee:17:36)
      at RobotMock.Robot (node_modules/hubot/src/robot.coffee:69:12)
      at new RobotMock (test/mock/robot.coffee:12:46)
      at Context.<anonymous> (test/typetalk.test.coffee:41:15)

  2) TypetalkStreaming "before each" hook for "should have configs from environment variables":
     TypeError: Cannot read property 'use' of undefined
      at RobotMock.loadAdapter (test/mock/robot.coffee:17:36)
      at RobotMock.Robot (node_modules/hubot/src/robot.coffee:69:12)
      at new RobotMock (test/mock/robot.coffee:12:46)
      at Context.<anonymous> (test/typetalk.test.coffee:66:15)
```


