### PR TITLE
Fix for 4 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "hubot": ">=2.6.0",
-    "request": "~2.33.0",
+    "request": "~2.74.0",
     "underscore": "~1.6.0",
     "ws": "~0.4.32"
   },


### PR DESCRIPTION
hubot-typetalk currently has a 8 vulnerable dependency paths, introducing 7 different types of known vulnerabilities.

This PR fixes vulnerable dependencies.
* [ReDOS vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency.
* [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.
* [Denial of Service (Event Loop Blocking)](https://snyk.io/vuln/npm:qs:20140806-1) vulnerability in the `qs` dependency.
* [Denial of Service (Memory Exhaustion)](https://snyk.io/vuln/npm:qs:20140806) vulnerability in the `qs` dependency.

You can see [Snyk test report](https://snyk.io/test/github/nulab/hubot-typetalk) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerabilities listed above.

You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade others dependencies as well.

Stay Secure,
The Snyk Team