### PR TITLE
Fix to disconnect by without ping

### DIFF
--- a/src/typetalk.coffee
+++ b/src/typetalk.coffee
@@ -85,9 +85,10 @@ class TypetalkStreaming extends EventEmitter
 
       ws.on 'open', () =>
         connected = true
-        setInterval =>
+        clearInterval timerId
+        timerId = setInterval =>
           ws.ping 'ping'
-        , 1000 * 60 * 10
+        , 1000 * 10 * 15
         @robot.logger.info "Typetalk WebSocket connected"
 
       ws.on 'error', (event) =>


### PR DESCRIPTION
Current Typetalk message server disconnect to client in 1 min.
This PR changes the time to 15 secs.