### PR TITLE
nulab-inc.com to nulab.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": {
     "name": "Nulab Developers",
     "email": "developer@nulab-inc.com",
-    "url": "http://developer.nulab-inc.com"
+    "url": "https://developer.nulab.com"
   },
   "license": "MIT",
   "readmeFilename": "README.md",


### PR DESCRIPTION
## Changes

- http://developer.nulab-inc.com -> https://developer.nulab.com