### PR TITLE
support NodeJS v18, drop NodeJS v12

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
         hubot-version: [^3.0]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
NodeJS v18 is currently LTS, and NodeJS v12 is already EOL.